### PR TITLE
feat: add CSV export to creator rewards dashboard

### DIFF
--- a/app/dashboard/creator/_components/CreatorRewardsPanel/CreatorRewardsPanel.tsx
+++ b/app/dashboard/creator/_components/CreatorRewardsPanel/CreatorRewardsPanel.tsx
@@ -1,12 +1,12 @@
 import { useGetRewardsFromCreator } from "../../../../../hooks/useGetRewardsFromCreator";
-import { Button, Divider, Loader, Space, Text } from "@mantine/core";
+import { Button, Divider, Loader, Space, Text, Group } from "@mantine/core";
 import { CreatorRewardCardSkeletonClient } from "../CreatorRewardCard/CreatorRewardCardSkeletonClient";
 import { CreatorRewardPaidCard } from "../CreatorRewardCard/CreatorRewardPaidCard";
 import { CreatorRewardUnpaidCard } from "../CreatorRewardCard/CreatorRewardUnpaidCard";
 import { InfinityList } from "../../../../_components/InfinityList";
 import { useGetFilteredByPlatform } from "../../../../../hooks/useGetFilteredByPlatform";
 import { NothingFound } from "../../../../_components/NothingFound";
-import { IconMoneybag } from "@tabler/icons-react";
+import { IconMoneybag, IconDownload } from "@tabler/icons-react";
 import { useDisclosure } from "@mantine/hooks";
 import { CreateNewRewardModal } from "./CreateNewRewardModal";
 import { mutate } from "swr";
@@ -26,6 +26,57 @@ export function CreatorRewardsPanel() {
 
     const noRewards = !hasUnpaidRewards && !hasPaidRewards;
 
+    const handleExportCSV = () => {
+        const headers = ["Issue ID", "Title", "Status", "Platform"];
+        const rows = issues.map((issue: any) => [
+            issue?.issueId || "",
+            `"${(issue?.title || "Reward Issue").replace(/"/g, '""')}"`,
+            issue?.isFullyPaid ? "Paid" : "Active",
+            issue?.platform || ""
+        ]);
+
+        const csvContent = [headers, ...rows].map(e => e.join(",")).join("\n");
+        const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
+        const link = document.createElement("a");
+        const url = URL.createObjectURL(blob);
+        link.setAttribute("href", url);
+        link.setAttribute("download", `opire_rewards.csv`);
+        link.style.visibility = 'hidden';
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+    };
+
+    const HeaderButtons = () => (
+        <div>
+            <Group>
+                <Button
+                    onClick={openModal}
+                    size='md'
+                    leftSection={<IconMoneybag size={14} />}
+                    variant='gradient'
+                >
+                    Create a new reward
+                </Button>
+                <Button 
+                    onClick={handleExportCSV} 
+                    size='md' 
+                    leftSection={<IconDownload size={14} />} 
+                    variant='outline' 
+                    color='violet'
+                >
+                    Export to CSV
+                </Button>
+            </Group>
+
+            <CreateNewRewardModal
+                isOpened={isModalOpen}
+                onClose={closeModal}
+                onNewRewardCreated={onNewRewardCreated}
+            />
+        </div>
+    );
+
     if (isLoading) {
         return <Loader display='block' size='xl' m='30px auto' />;
     }
@@ -33,22 +84,7 @@ export function CreatorRewardsPanel() {
     if (noRewards) {
         return (
             <div>
-                <div>
-                    <Button
-                        onClick={openModal}
-                        size='md'
-                        leftSection={<IconMoneybag size={14} />}
-                        variant='gradient'
-                    >
-                        Create a new reward
-                    </Button>
-
-                    <CreateNewRewardModal
-                        isOpened={isModalOpen}
-                        onClose={closeModal}
-                        onNewRewardCreated={onNewRewardCreated}
-                    />
-                </div>
+                <HeaderButtons />
 
                 <Space h='xl' />
 
@@ -59,22 +95,7 @@ export function CreatorRewardsPanel() {
 
     return (
         <div>
-            <div>
-                <Button
-                    onClick={openModal}
-                    size='md'
-                    leftSection={<IconMoneybag size={14} />}
-                    variant='gradient'
-                >
-                    Create a new reward
-                </Button>
-
-                <CreateNewRewardModal
-                    isOpened={isModalOpen}
-                    onClose={closeModal}
-                    onNewRewardCreated={onNewRewardCreated}
-                />
-            </div>
+            <HeaderButtons />
 
             <Space h='xl' />
 

--- a/app/dashboard/creator/rewards/page.tsx
+++ b/app/dashboard/creator/rewards/page.tsx
@@ -7,6 +7,7 @@ export const metadata: Metadata = {
 };
 
 export default async function Page () {
+    // Restored the real server guard!
     redirectToHomeIfNotLogged();
 
     return (


### PR DESCRIPTION
## 🏷️ Type of PR
- [x] 🛠️ Feature Implementation

## 📋 Required Checks
- [x] 👀 I Read the Contributing Guide
- [x] ✅ The Test are Passing
- [x] 💅 The Code is Linted
- [x] 🗂️ The Code is Well Structured

## 📝 Description of the Changes
Added a new "Export to CSV" button to the Creator Rewards Panel. This allows creators to download a structured report of all their Active and Paid rewards directly from the dashboard for accounting and tracking purposes.

## 📋 Other Checks
- [x] Affects the UI

## 📌 Reference Issues (Optional)
Closes #42

## 🔍 Anything else? (Optional)
This implementation is client-side only and processes the existing reward data into a downloadable Blob format to ensure fast performance without extra API overhead.